### PR TITLE
Chapter 3 Using stubs to break dependencies

### DIFF
--- a/ArtOfUnitTest2nd/LogAn.UnitTests/LogAnalyzerTests.cs
+++ b/ArtOfUnitTest2nd/LogAn.UnitTests/LogAnalyzerTests.cs
@@ -147,5 +147,18 @@ namespace LogAn.UnitTests
 
             Assert.Equal(expected, analyzer.WasLastFileNameValid);
         }
+
+
+        [Fact]
+        public void IsValid_FileName_SupportedExtension_ReturnsTrue()
+        {
+            var myFakeManager = new FakeExtensionManager();
+            myFakeManager.WillBeValid = true;
+
+            var log = new LogAnalyzer(myFakeManager);
+
+            var result = log.IsValidLogFileName("short.ext");
+            Assert.True(result);
+        }
     }
 }

--- a/ArtOfUnitTest2nd/LogAn.UnitTests/LogAnalyzerTests.cs
+++ b/ArtOfUnitTest2nd/LogAn.UnitTests/LogAnalyzerTests.cs
@@ -220,6 +220,8 @@ namespace LogAn.UnitTests
             var stub = new FakeExtensionManager();
             stub.WillBeValid = true;
 
+            // オーバーライド可能なメソッドを持つテストクラスを作って
+            // Injectionする
             var logan = new TestableLogAnalyzer(stub);
 
             var result = logan.IsValidLogFileName("file.ext");
@@ -227,9 +229,23 @@ namespace LogAn.UnitTests
             Assert.True(result);
         }
 
+        [Fact]
+        public void OverrideTestWithoutStub()
+        {
+            var logan = new TestableLogAnalyzer();
+            logan.IsSupported = true;
+
+            bool result = logan.IsValidLogFileNameByOverrideResult("file.ext");
+
+            Assert.True(result);
+        }
+
         class TestableLogAnalyzer : LogAnalyzerUsingFactoryMethod
         {
             public IExtensionManager Manager;
+            public bool IsSupported;
+
+            public TestableLogAnalyzer() { }
 
             public TestableLogAnalyzer(IExtensionManager mgr)
             {
@@ -239,6 +255,11 @@ namespace LogAn.UnitTests
             protected override IExtensionManager GetManager()
             {
                 return Manager;
+            }
+
+            protected override bool IsValid(string fileName)
+            {
+                return IsSupported;
             }
         }
     }

--- a/ArtOfUnitTest2nd/LogAn.UnitTests/LogAnalyzerTests.cs
+++ b/ArtOfUnitTest2nd/LogAn.UnitTests/LogAnalyzerTests.cs
@@ -168,12 +168,30 @@ namespace LogAn.UnitTests
             var myFakeManager = new FakeExtensionManager();
             myFakeManager.WillThrow = new Exception("this is fake");
 
+            // コンストラクタでInjectionする
             var log = new LogAnalyzer(myFakeManager);
 
             var exception = Assert.Throws<Exception>(
                 () => log.IsValidLogFileName("anything.anyextension"));
 
             Assert.Equal("this is fake", exception.Message);
+        }
+
+
+        [Fact]
+        public void IsValidFileName_ExtManagerThrowsExceptionByProperty_ReturnsFalse()
+        {
+            var myFakeManager = new FakeExtensionManager();
+            myFakeManager.WillThrow = new Exception("this is fake by property");
+
+            // プロパティでInjectionする
+            var log = new LogAnalyzer();
+            log.ExtensionManager = myFakeManager;
+
+            var exception = Assert.Throws<Exception>(
+                () => log.IsValidLogFileName("anything.anyextension"));
+
+            Assert.Equal("this is fake by property", exception.Message);
         }
     }
 }

--- a/ArtOfUnitTest2nd/LogAn.UnitTests/LogAnalyzerTests.cs
+++ b/ArtOfUnitTest2nd/LogAn.UnitTests/LogAnalyzerTests.cs
@@ -232,6 +232,10 @@ namespace LogAn.UnitTests
         [Fact]
         public void OverrideTestWithoutStub()
         {
+            // FakeExtensionManagerというスタブを用意せずに、
+            // オーバーライド可能なメソッドを持つテストクラスを作って
+            // Injectionする
+            // ->スタブがない分、シンプルになる(位置No.1692)
             var logan = new TestableLogAnalyzer();
             logan.IsSupported = true;
 

--- a/ArtOfUnitTest2nd/LogAn.UnitTests/LogAnalyzerTests.cs
+++ b/ArtOfUnitTest2nd/LogAn.UnitTests/LogAnalyzerTests.cs
@@ -160,5 +160,20 @@ namespace LogAn.UnitTests
             var result = log.IsValidLogFileName("short.ext");
             Assert.True(result);
         }
+
+
+        [Fact]
+        public void IsValidFileName_ExtManagerThrowsException_ReturnsFalse()
+        {
+            var myFakeManager = new FakeExtensionManager();
+            myFakeManager.WillThrow = new Exception("this is fake");
+
+            var log = new LogAnalyzer(myFakeManager);
+
+            var exception = Assert.Throws<Exception>(
+                () => log.IsValidLogFileName("anything.anyextension"));
+
+            Assert.Equal("this is fake", exception.Message);
+        }
     }
 }

--- a/ArtOfUnitTest2nd/LogAn/AlwaysValidFakeExtensionManager.cs
+++ b/ArtOfUnitTest2nd/LogAn/AlwaysValidFakeExtensionManager.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace LogAn
+{
+    public class AlwaysValidFakeExtensionManager : IExtensionManager
+    {
+        public bool IsValid(string fileName)
+        {
+            return true;
+        }
+    }
+}

--- a/ArtOfUnitTest2nd/LogAn/ExtensionManagerFactory.cs
+++ b/ArtOfUnitTest2nd/LogAn/ExtensionManagerFactory.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace LogAn
+{
+    public class ExtensionManagerFactory
+    {
+        // 位置No1581ではstaticになっていなかったが、
+        // 本文に合わせていずれもstaticで作った
+        private static IExtensionManager customManager = null;
+
+        /// <summary>
+        /// ファクトリメソッド
+        /// </summary>
+        /// <returns></returns>
+        public static IExtensionManager Create()
+        {
+            if (customManager != null)
+            {
+                return customManager;
+            }
+
+            return new FileExtensionManager();
+        }
+
+        
+        /// <summary>
+        /// ファクトリメソッドで使うインスタンスをセットする
+        /// </summary>
+        /// <param name="mgr"></param>
+        public static void SetManager(IExtensionManager mgr)
+        {
+            customManager = mgr;
+        }
+    }
+}

--- a/ArtOfUnitTest2nd/LogAn/FakeExtensionManager.cs
+++ b/ArtOfUnitTest2nd/LogAn/FakeExtensionManager.cs
@@ -9,9 +9,15 @@ namespace LogAn
     public class FakeExtensionManager : IExtensionManager
     {
         public bool WillBeValid = false;
+        public Exception WillThrow = null;
 
         public bool IsValid(string fileName)
         {
+            if (WillThrow != null)
+            {
+                throw WillThrow;
+            }
+
             return WillBeValid;
         }
     }

--- a/ArtOfUnitTest2nd/LogAn/FakeExtensionManager.cs
+++ b/ArtOfUnitTest2nd/LogAn/FakeExtensionManager.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace LogAn
+{
+    public class FakeExtensionManager : IExtensionManager
+    {
+        public bool WillBeValid = false;
+
+        public bool IsValid(string fileName)
+        {
+            return WillBeValid;
+        }
+    }
+}

--- a/ArtOfUnitTest2nd/LogAn/FileExtensionManager.cs
+++ b/ArtOfUnitTest2nd/LogAn/FileExtensionManager.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace LogAn
+{
+    public class FileExtensionManager : IExtensionManager
+    {
+        public bool IsValid(string fileName)
+        {
+            if (string.IsNullOrEmpty(fileName))
+            {
+                throw new ArgumentException("filename has to be provided");
+            }
+
+            if (!fileName.EndsWith(".SLF", StringComparison.CurrentCultureIgnoreCase))
+            {
+                return false;
+            }
+   
+            return true;
+        }
+
+
+    }
+
+    
+}

--- a/ArtOfUnitTest2nd/LogAn/IExtensionManager.cs
+++ b/ArtOfUnitTest2nd/LogAn/IExtensionManager.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace LogAn
+{
+    public interface IExtensionManager
+    {
+        bool IsValid(string fileName);
+    }
+}

--- a/ArtOfUnitTest2nd/LogAn/LogAn.csproj
+++ b/ArtOfUnitTest2nd/LogAn/LogAn.csproj
@@ -46,6 +46,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AlwaysValidFakeExtensionManager.cs" />
+    <Compile Include="FakeExtensionManager.cs" />
     <Compile Include="FileExtensionManager.cs" />
     <Compile Include="IExtensionManager.cs" />
     <Compile Include="LogAnalyzer.cs" />

--- a/ArtOfUnitTest2nd/LogAn/LogAn.csproj
+++ b/ArtOfUnitTest2nd/LogAn/LogAn.csproj
@@ -45,6 +45,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AlwaysValidFakeExtensionManager.cs" />
+    <Compile Include="FileExtensionManager.cs" />
+    <Compile Include="IExtensionManager.cs" />
     <Compile Include="LogAnalyzer.cs" />
     <Compile Include="MemCalculator.cs" />
     <Compile Include="Program.cs" />

--- a/ArtOfUnitTest2nd/LogAn/LogAn.csproj
+++ b/ArtOfUnitTest2nd/LogAn/LogAn.csproj
@@ -46,10 +46,12 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AlwaysValidFakeExtensionManager.cs" />
+    <Compile Include="ExtensionManagerFactory.cs" />
     <Compile Include="FakeExtensionManager.cs" />
     <Compile Include="FileExtensionManager.cs" />
     <Compile Include="IExtensionManager.cs" />
     <Compile Include="LogAnalyzer.cs" />
+    <Compile Include="LogAnalyzerUsingFactoryMethod.cs" />
     <Compile Include="MemCalculator.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/ArtOfUnitTest2nd/LogAn/LogAnalyzer.cs
+++ b/ArtOfUnitTest2nd/LogAn/LogAnalyzer.cs
@@ -6,11 +6,17 @@ using System.Threading.Tasks;
 
 namespace LogAn
 {
+    // internalなコンストラクタをテストから見えるようにするため、
+    // 属性を付与する
+    using System.Runtime.CompilerServices;
+    [assembly: InternalsVisibleTo("LogAn.UnitTests")]
     public class LogAnalyzer
     {
         public bool WasLastFileNameValid { get; set; }
 
         private IExtensionManager manager;
+
+        // ---コンストラクタ系
 
         // ファクトリメソッドを使って、IExtensionManagerのインスタンスを生成
         public LogAnalyzer()
@@ -23,6 +29,16 @@ namespace LogAn
         {
             manager = mgr;
         }
+
+        // 通常は外部から見えないが、上記のとおりに
+        // [InternalsVisibleTo()]を使うことで、
+        // テストクラスからも見えるようになる
+        // ＊ビルドできるよう、便宜上、引数の型を変えている
+        internal LogAnalyzer(FileExtensionManager extensionManager)
+        {
+            manager = extensionManager;
+        }
+
 
         // テストコードからInjectionすることのできるプロパティを作成
         public IExtensionManager ExtensionManager

--- a/ArtOfUnitTest2nd/LogAn/LogAnalyzer.cs
+++ b/ArtOfUnitTest2nd/LogAn/LogAnalyzer.cs
@@ -12,10 +12,10 @@ namespace LogAn
 
         private IExtensionManager manager;
 
-        // 過去との互換性のため、引数なしのコンストラクタも用意
+        // ファクトリメソッドを使って、IExtensionManagerのインスタンスを生成
         public LogAnalyzer()
         {
-            manager = new FileExtensionManager();
+            manager = ExtensionManagerFactory.Create();
         }
 
         // テストコードから呼ぶことのできる(Injectionする)コンストラクタを作成

--- a/ArtOfUnitTest2nd/LogAn/LogAnalyzer.cs
+++ b/ArtOfUnitTest2nd/LogAn/LogAnalyzer.cs
@@ -14,23 +14,10 @@ namespace LogAn
         {
             WasLastFileNameValid = false;
 
-            if (string.IsNullOrEmpty(fileName))
-            {
-                throw new ArgumentException("filename has to be provided");
-            }
+            IExtensionManager mgr = new FileExtensionManager();
+            WasLastFileNameValid = mgr.IsValid(fileName);
 
-            if (!fileName.EndsWith(".SLF", StringComparison.CurrentCultureIgnoreCase))
-            {
-                return false;
-            }
-
-            // read through the configuration file
-
-            // reaturn true if configuration says extension is supported
-
-
-            WasLastFileNameValid = true;
-            return true;
+            return WasLastFileNameValid;
         }
     }
 }

--- a/ArtOfUnitTest2nd/LogAn/LogAnalyzer.cs
+++ b/ArtOfUnitTest2nd/LogAn/LogAnalyzer.cs
@@ -24,6 +24,11 @@ namespace LogAn
                 return false;
             }
 
+            // read through the configuration file
+
+            // reaturn true if configuration says extension is supported
+
+
             WasLastFileNameValid = true;
             return true;
         }

--- a/ArtOfUnitTest2nd/LogAn/LogAnalyzer.cs
+++ b/ArtOfUnitTest2nd/LogAn/LogAnalyzer.cs
@@ -10,12 +10,25 @@ namespace LogAn
     {
         public bool WasLastFileNameValid { get; set; }
 
+        private IExtensionManager manager;
+
+        // 過去との互換性のため、引数なしのコンストラクタも用意
+        public LogAnalyzer()
+        {
+            manager = new FileExtensionManager();
+        }
+
+        // テストコードから呼ぶことのできるコンストラクタを作成
+        public LogAnalyzer(IExtensionManager mgr)
+        {
+            manager = mgr;
+        }
+
         public bool IsValidLogFileName(string fileName)
         {
             WasLastFileNameValid = false;
 
-            IExtensionManager mgr = new FileExtensionManager();
-            WasLastFileNameValid = mgr.IsValid(fileName);
+            WasLastFileNameValid = manager.IsValid(fileName);
 
             return WasLastFileNameValid;
         }

--- a/ArtOfUnitTest2nd/LogAn/LogAnalyzer.cs
+++ b/ArtOfUnitTest2nd/LogAn/LogAnalyzer.cs
@@ -18,11 +18,19 @@ namespace LogAn
             manager = new FileExtensionManager();
         }
 
-        // テストコードから呼ぶことのできるコンストラクタを作成
+        // テストコードから呼ぶことのできる(Injectionする)コンストラクタを作成
         public LogAnalyzer(IExtensionManager mgr)
         {
             manager = mgr;
         }
+
+        // テストコードからInjectionすることのできるプロパティを作成
+        public IExtensionManager ExtensionManager
+        {
+            get { return manager; }
+            set { manager = value; }
+        }
+        
 
         public bool IsValidLogFileName(string fileName)
         {

--- a/ArtOfUnitTest2nd/LogAn/LogAnalyzerUsingFactoryMethod.cs
+++ b/ArtOfUnitTest2nd/LogAn/LogAnalyzerUsingFactoryMethod.cs
@@ -13,6 +13,17 @@ namespace LogAn
             return GetManager().IsValid(fileName);
         }
 
+        public bool IsValidLogFileNameByOverrideResult(string fileName)
+        {
+            return this.IsValid(fileName);
+        }
+
+        protected virtual bool IsValid(string fileName)
+        {
+            var mgr = new FileExtensionManager();
+            return mgr.IsValid(fileName);
+        }
+
         // protected virtualにすることで、
         // テストにて継承・オーバーライドの利用を可能にする
         protected virtual IExtensionManager GetManager()

--- a/ArtOfUnitTest2nd/LogAn/LogAnalyzerUsingFactoryMethod.cs
+++ b/ArtOfUnitTest2nd/LogAn/LogAnalyzerUsingFactoryMethod.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace LogAn
+{
+    public class LogAnalyzerUsingFactoryMethod
+    {
+        public bool IsValidLogFileName(string fileName)
+        {
+            return GetManager().IsValid(fileName);
+        }
+
+        // protected virtualにすることで、
+        // テストにて継承・オーバーライドの利用を可能にする
+        protected virtual IExtensionManager GetManager()
+        {
+            // ハードコードした値を返す
+            return new FileExtensionManager();
+        }
+    }
+}


### PR DESCRIPTION
- 位置No.1436 > stub classの名前は `Fake...`として、`Stub...`や`Mock...`は使わない
- 位置No.1497 >  テストのためのコンストラクタ引数が増えたら、invension of control (IoC) container を使うことも検討する
  - Microsoft Unity, StructureMap, Castle Windsor, etc..
  - [List of .NET Dependency Injection Containers (IOC) - Scott Hanselman](http://www.hanselman.com/blog/ListOfNETDependencyInjectionContainersIOC.aspx)
  - [Manning: Dependency Injection in .NET](http://www.manning.com/seemann/)
  - [Amazon.co.jp： Clean Code アジャイルソフトウェア達人の技: Robert C. Martin, 花井 志生: 本](http://www.amazon.co.jp/dp/4048676881)
- 位置No.1525 > ほとんどのケースではコンストラクタ引数で良く、プロパティも時々使われる
- 位置No.1720 > `[InternalVisibleTo]`で、internalなクラスでもテストを可能にする
- 位置No.1720 > `[Conditional]`attribute (`System.Diagnostics.ConditionalAttribute`) も利用可能
- ただし、アトリビュートは可読性を下げたりするので、注意して使う
- 位置No.1737 > `#if DEBUG`も使えるが、乱雑になるので、`[InternalVisibleTo]`の方が望ましい
