### PR TITLE
Chapter 4 Interaction testing using mock objects

### DIFF
--- a/ArtOfUnitTest2nd/LogAn.UnitTests/EmailInfo.cs
+++ b/ArtOfUnitTest2nd/LogAn.UnitTests/EmailInfo.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace LogAn.UnitTests
+{
+    public class EmailInfo
+    {
+        public string Body;
+        public string To;
+        public string Subject;
+    }
+}

--- a/ArtOfUnitTest2nd/LogAn.UnitTests/EmailInfoComparer.cs
+++ b/ArtOfUnitTest2nd/LogAn.UnitTests/EmailInfoComparer.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace LogAn.UnitTests
+{
+    public class EmailInfoComparer : IEqualityComparer<EmailInfo>
+    {
+        public bool Equals(EmailInfo x, EmailInfo y)
+        {
+            return
+                x.To.Equals(y.To, StringComparison.Ordinal) &&
+                x.Subject.Equals(y.Subject, StringComparison.Ordinal) &&
+                x.Body.Equals(y.Body, StringComparison.Ordinal);
+        }
+
+        public int GetHashCode(EmailInfo info)
+        {
+            return
+                info.To.GetHashCode() ^
+                info.Subject.GetHashCode() ^
+                info.Body.GetHashCode();
+        }
+    }
+}

--- a/ArtOfUnitTest2nd/LogAn.UnitTests/FakeEmailService.cs
+++ b/ArtOfUnitTest2nd/LogAn.UnitTests/FakeEmailService.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace LogAn.UnitTests
+{
+    public class FakeEmailService : IEmailService
+    {
+        // 複数のプロパティをテスト対象とするなら、
+        // 一つのオブジェクトにまとめたほうが分かりやすく変更にも強いので
+        // こちらよりは、
+        //public string To;
+        //public string Subject;
+        //public string Body;
+        //public void SendEmail(string to, string subject, string body)
+        //{
+        //    To = to;
+        //    Subject = subject;
+        //    Body = body;
+        //}
+
+        // こちらのほうが良い
+        public EmailInfo email = null;
+        public void SendEmail(string to, string subject, string body)
+        {
+            email = new EmailInfo()
+            {
+                To = to,
+                Subject = subject,
+                Body = body
+            };
+        }
+    }
+}

--- a/ArtOfUnitTest2nd/LogAn.UnitTests/FakeExtensionManager.cs
+++ b/ArtOfUnitTest2nd/LogAn.UnitTests/FakeExtensionManager.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace LogAn
+namespace LogAn.UnitTests
 {
     public class FakeExtensionManager : IExtensionManager
     {

--- a/ArtOfUnitTest2nd/LogAn.UnitTests/FakeWebService.cs
+++ b/ArtOfUnitTest2nd/LogAn.UnitTests/FakeWebService.cs
@@ -4,17 +4,26 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace LogAn
+namespace LogAn.UnitTests
 {
     public class FakeWebService : IWebService
     {
         public string LastError;
+        public Exception ToThrow;
 
         public void LogError(string message)
         {
+            if (ToThrow != null)
+            {
+                throw ToThrow;
+            }
+
             // テストに使う内容は外部から引数として受け取り、
             // Mockの中には記載しない
             LastError = message;
         }
+
+
+        
     }
 }

--- a/ArtOfUnitTest2nd/LogAn.UnitTests/LogAn.UnitTests.csproj
+++ b/ArtOfUnitTest2nd/LogAn.UnitTests/LogAn.UnitTests.csproj
@@ -52,6 +52,11 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="EmailInfo.cs" />
+    <Compile Include="EmailInfoComparer.cs" />
+    <Compile Include="FakeEmailService.cs" />
+    <Compile Include="FakeExtensionManager.cs" />
+    <Compile Include="FakeWebService.cs" />
     <Compile Include="LogAnalyzerTests.cs" />
     <Compile Include="MemCalculatorTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/ArtOfUnitTest2nd/LogAn.UnitTests/LogAnalyzerTests.cs
+++ b/ArtOfUnitTest2nd/LogAn.UnitTests/LogAnalyzerTests.cs
@@ -282,5 +282,38 @@ namespace LogAn.UnitTests
         }
 
         
+        [Fact]
+        public void Analyze_WebServiceThrows_SendMail()
+        {
+            // stubとmockを組み合わせるテスト
+            var stubService = new FakeWebService();
+            stubService.ToThrow = new Exception("fake exception");
+
+            var mockEmail = new FakeEmailService();
+
+            var log = new LogAnalyzer(stubService, mockEmail);
+            var tooShortFileName = "abc.ext";
+
+            log.Analyze(tooShortFileName);
+
+            // 複数のプロパティをテスト対象とするなら、
+            // 一つのオブジェクトにまとめたほうが分かりやすく変更にも強いので
+            // こちらよりは、
+            //Assert.Contains("someone@somewhere.com", mockEmail.To);
+            //Assert.Contains("fake exception", mockEmail.Body);
+            //Assert.Contains("can't loga", mockEmail.Subject);
+
+            // こちらのほうが良い
+            var expectEmail = new EmailInfo()
+            {
+                Body = "fake exception",
+                To = "someone@somewhere.com",
+                Subject = "can't log"
+            };
+
+            // xUnit.netの場合、Equalの第三引数に
+            // IEqualityComparerを実装した比較用クラスを渡す
+            Assert.Equal(expectEmail, mockEmail.email, new EmailInfoComparer());
+        }
     }
 }

--- a/ArtOfUnitTest2nd/LogAn.UnitTests/LogAnalyzerTests.cs
+++ b/ArtOfUnitTest2nd/LogAn.UnitTests/LogAnalyzerTests.cs
@@ -266,5 +266,21 @@ namespace LogAn.UnitTests
                 return IsSupported;
             }
         }
+
+
+        [Fact]
+        public void Analyze_TooShortFileName_CallsWebService()
+        {
+            // Webサービスとのテストで、mockを使う方法
+            var mockWebService = new FakeWebService();
+            var log = new LogAnalyzer(mockWebService);
+            var tooShortFileName = "abc.ext";
+
+            log.Analyze(tooShortFileName);
+
+            Assert.Contains("FileName too short:abc.ext", mockWebService.LastError);
+        }
+
+        
     }
 }

--- a/ArtOfUnitTest2nd/LogAn/FakeWebService.cs
+++ b/ArtOfUnitTest2nd/LogAn/FakeWebService.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace LogAn
+{
+    public class FakeWebService : IWebService
+    {
+        public string LastError;
+
+        public void LogError(string message)
+        {
+            // テストに使う内容は外部から引数として受け取り、
+            // Mockの中には記載しない
+            LastError = message;
+        }
+    }
+}

--- a/ArtOfUnitTest2nd/LogAn/IEmailService.cs
+++ b/ArtOfUnitTest2nd/LogAn/IEmailService.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace LogAn
+{
+    public interface IEmailService
+    {
+        void SendEmail(string to, string subject, string body);
+    }
+}

--- a/ArtOfUnitTest2nd/LogAn/IWebService.cs
+++ b/ArtOfUnitTest2nd/LogAn/IWebService.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace LogAn
+{
+    public interface IWebService
+    {
+        void LogError(string message);
+    }
+}

--- a/ArtOfUnitTest2nd/LogAn/LogAn.csproj
+++ b/ArtOfUnitTest2nd/LogAn/LogAn.csproj
@@ -47,9 +47,8 @@
   <ItemGroup>
     <Compile Include="AlwaysValidFakeExtensionManager.cs" />
     <Compile Include="ExtensionManagerFactory.cs" />
-    <Compile Include="FakeExtensionManager.cs" />
-    <Compile Include="FakeWebService.cs" />
     <Compile Include="FileExtensionManager.cs" />
+    <Compile Include="IEmailService.cs" />
     <Compile Include="IExtensionManager.cs" />
     <Compile Include="IWebService.cs" />
     <Compile Include="LogAnalyzer.cs" />

--- a/ArtOfUnitTest2nd/LogAn/LogAn.csproj
+++ b/ArtOfUnitTest2nd/LogAn/LogAn.csproj
@@ -48,8 +48,10 @@
     <Compile Include="AlwaysValidFakeExtensionManager.cs" />
     <Compile Include="ExtensionManagerFactory.cs" />
     <Compile Include="FakeExtensionManager.cs" />
+    <Compile Include="FakeWebService.cs" />
     <Compile Include="FileExtensionManager.cs" />
     <Compile Include="IExtensionManager.cs" />
+    <Compile Include="IWebService.cs" />
     <Compile Include="LogAnalyzer.cs" />
     <Compile Include="LogAnalyzerUsingFactoryMethod.cs" />
     <Compile Include="MemCalculator.cs" />

--- a/ArtOfUnitTest2nd/LogAn/LogAnalyzer.cs
+++ b/ArtOfUnitTest2nd/LogAn/LogAnalyzer.cs
@@ -57,19 +57,35 @@ namespace LogAn
         }
 
 
-        // Webサービスとのテスト向け
-        private IWebService service;
+        //------- Webサービスとのテスト向け
+        public IWebService Service { get; set; }
+        public IEmailService Email { get; set; }
 
         public LogAnalyzer(IWebService service)
         {
-            this.service = service;
+            // Webサービス単体
+            Service = service;
+        }
+
+        public LogAnalyzer(IWebService service, IEmailService email)
+        {
+            // WebサービスとEmailサービスとの連携
+            Service = service;
+            Email = email;
         }
 
         public void Analyze(string fileName)
         {
             if (fileName.Length < 8)
             {
-                service.LogError("FileName too short:" + fileName);
+                try
+                {
+                    Service.LogError("FileName too short:" + fileName);
+                }
+                catch (Exception e)
+                {
+                    Email.SendEmail("someone@somewhere.com", "can't log", e.Message);
+                }
             }
         }
     }

--- a/ArtOfUnitTest2nd/LogAn/LogAnalyzer.cs
+++ b/ArtOfUnitTest2nd/LogAn/LogAnalyzer.cs
@@ -16,7 +16,6 @@ namespace LogAn
 
         private IExtensionManager manager;
 
-        // ---コンストラクタ系
 
         // ファクトリメソッドを使って、IExtensionManagerのインスタンスを生成
         public LogAnalyzer()
@@ -55,6 +54,23 @@ namespace LogAn
             WasLastFileNameValid = manager.IsValid(fileName);
 
             return WasLastFileNameValid;
+        }
+
+
+        // Webサービスとのテスト向け
+        private IWebService service;
+
+        public LogAnalyzer(IWebService service)
+        {
+            this.service = service;
+        }
+
+        public void Analyze(string fileName)
+        {
+            if (fileName.Length < 8)
+            {
+                service.LogError("FileName too short:" + fileName);
+            }
         }
     }
 }


### PR DESCRIPTION
- 位置No.1868 > テストに使う内容は外部から引数として受け取り、Mockの中には記載しない
- 位置No.1872 > 「4.3 Using a mock and a stub together」では、Webサービスと連携後、エラーがあればWeb管理者にメールを送信
- `StringAssert.Contains`は、xUnit.netでは、`Assert.Contains`
- `テスト > 実行 > すべてのテスト`の場合は、テストに失敗すると例外が出る
- 一方、テストエクスプローラーのxUnit.net Runnerにある`すべて実行`ではテストに失敗すると失敗テストに表示される
  - 型 'Xunit.Sdk.ContainsException' の例外が xunit.assert.dll で発生しましたが、ユーザー コード内ではハンドルされませんでした　追加情報:Assert.Contains() Failure
- ショートカットを使いつつ例外で止めないためには、一度全テストを実行した後に、`Ctrl + R, L`(直前の実行の繰り返し)を使うことで、テストに失敗しても例外が出ずに失敗テストに表示される
- 位置No.1927 > 複数のAssertをテストに入れると分かりづらい。また、複数のプロパティを複数のAssertでテストするよりは、それらのプロパティを一つのオブジェクトにまとめて一つのAssertでテストしたほうがよい
- 位置No.1936 > NUnitと異なり、xUnit.netでは`Assert.Equal(expectEmail, mockEmail.email);`が通らない。第三引数に`IEqualityComparer`を実装した比較用のクラスを渡す(`Assert.Equal(expectEmail, mockEmail.email, new EmailInfoComparer());`)ことで通る
  - [c# - How to Compare two objects in unit test? - Stack Overflow](http://stackoverflow.com/questions/2046121/how-to-compare-two-objects-in-unit-test)
- `Assert.True(expectEmail.Equals(mockEmail.email));`は通らない。 
  - [unit testing - How to test two objects are equal in xunit.net? - Stack Overflow](http://stackoverflow.com/questions/10365699/how-to-test-two-objects-are-equal-in-xunit-net?lq=1)
- xUnit.net v2には、`Assert.StrictEqual`もある模様
  - [xUnit.net - Unit testing framework for C# and .NET (a successor to NUnit) - View Issue #9856: Make Assert.Equal less intelligent](https://xunit.codeplex.com/workitem/9856)
